### PR TITLE
Use ubuntu 20.04 and hibiscus-server-2.10.9 in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,12 @@ FROM ubuntu:20.04
 RUN apt-get update && apt-get -y upgrade
 RUN apt-get -y install openjdk-8-jdk wget unzip
 
-RUN wget https://www.willuhn.de/products/hibiscus-server/releases/hibiscus-server-2.10.9.zip 
+
+# For direct download from willuhn.de:
+# RUN wget https://www.willuhn.de/products/hibiscus-server/releases/hibiscus-server-2.10.9.zip 
+# But let's use the copy included in ./vendor/ instead:
+COPY vendor/willuhn/hibiscus-server-2.10.9.zip ./hibiscus-server-2.10.9.zip
+
 RUN unzip ./hibiscus-server-2.10.9.zip 
 
 ADD wrap.sh /wrap

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,8 +6,8 @@ FROM ubuntu:20.04
 RUN apt-get update && apt-get -y upgrade
 RUN apt-get -y install openjdk-8-jdk wget unzip
 
-RUN wget https://www.willuhn.de/products/hibiscus-server/releases/hibiscus-server-2.10.4.zip 
-RUN unzip ./hibiscus-server-2.10.4.zip 
+RUN wget https://www.willuhn.de/products/hibiscus-server/releases/hibiscus-server-2.10.9.zip 
+RUN unzip ./hibiscus-server-2.10.9.zip 
 
 ADD wrap.sh /wrap
 ENTRYPOINT ["/wrap"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:18.04
+FROM ubuntu:20.04
 
 # Enable this during development.
 #RUN echo 'Acquire::http { Proxy "http://192.168.59.103:3142"; };' >> /etc/apt/apt.conf.d/01proxy
@@ -6,8 +6,8 @@ FROM ubuntu:18.04
 RUN apt-get update && apt-get -y upgrade
 RUN apt-get -y install openjdk-8-jdk wget unzip
 
-RUN wget https://www.willuhn.de/products/hibiscus-server/releases/hibiscus-server-2.8.16.zip
-RUN unzip hibiscus-server-2.8.16.zip -d / && rm hibiscus-server-2.8.16.zip
+RUN wget https://www.willuhn.de/products/hibiscus-server/releases/hibiscus-server-2.10.4.zip 
+RUN unzip ./hibiscus-server-2.10.4.zip 
 
 ADD wrap.sh /wrap
 ENTRYPOINT ["/wrap"]

--- a/README.md
+++ b/README.md
@@ -7,8 +7,11 @@ Hibiscus Payment-Server Docker Image
 
 Usage:
 
-    $ docker run -e PASSWORD=foo -p 8080:8080 schlickspringer/docker-hibiscus-server
-
+```
+TAG=docker-hibiscus-server:local
+docker build -t $TAG .
+docker run -e PASSWORD=foo -p 8080:8080 $TAG
+```
 
 **PASSWORD** is the (required) password used to encrypt the database.
 

--- a/vendor/willuhn/LICENSE
+++ b/vendor/willuhn/LICENSE
@@ -1,0 +1,27 @@
+May 11, 2018
+
+Jameica is licensed under the terms of the GNU General Public License version 2 or later.
+
+Linking this program statically or dynamically with other modules is making a
+combined work based on this program. Thus, the terms and conditions of the
+GNU General Public License cover the whole combination.
+
+As a special exception, the copyright holders of this program give you
+permission to link this program with independent modules to produce an
+executable, regardless of the license terms of these independent modules, and
+to copy and distribute the resulting executable under terms of your choice,
+provided that you also meet, for each linked independent module, the terms and
+conditions of the license of that module. An independent module is a module
+which is not derived from or based on this program.  If you modify this program,
+you may extend this exception to your version of the program, but you are not
+obligated to do so.  If you do not wish to do so, delete this exception
+statement from your version.
+
+You should have received a copy of the GNU General Public License along with
+Jameica; see the file COPYING.  If not, write to
+
+Free Software Foundation, Inc.
+51 Franklin St, Fifth Floor
+Boston
+MA 02110-1301
+USA


### PR DESCRIPTION
The docker build and docker run looks good, but no further testing yet.

```
$ docker logs 0f8949dab9f3 | tail -n5

[Wed Jun 28 11:00:01 GMT 2023][INFO][pool-1-thread-1][de.willuhn.jameica.sensors.service.impl.RRDImpl.store] creating new rrd file /srv/hibiscus/jameica.sensors/hibiscus.server.scheduler.device/hibiscus.server.scheduler.device.scheduler.rrd
[Wed Jun 28 11:00:01 GMT 2023][INFO][pool-1-thread-1][de.willuhn.jameica.sensors.service.impl.RRDImpl.store] creating new rrd file /srv/hibiscus/jameica.sensors/hibiscus.server.scheduler.device/hibiscus.server.scheduler.device.scheduler.status.rrd
[Wed Jun 28 11:05:00 GMT 2023][INFO][scheduler service][de.willuhn.jameica.sensors.service.impl.SchedulerImpl$Worker.run] collected data from device: JVM Statistics
[Wed Jun 28 11:05:00 GMT 2023][INFO][scheduler service][de.willuhn.jameica.sensors.service.impl.SchedulerImpl$Worker.run] collected data from device: hibiscus.server: account statistics
[Wed Jun 28 11:05:00 GMT 2023][INFO][scheduler service][de.willuhn.jameica.sensors.service.impl.SchedulerImpl$Worker.run] collected data from device: hibiscus.server: scheduler statistics
```